### PR TITLE
upgrade deweb plugin to 0.4.12 

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -34,23 +34,23 @@
     "description": "Your private access to DeWeb",
     "assets": {
       "windows": {
-        "url": "https://massa-station-assets.s3.eu-west-3.amazonaws.com/plugins/deweb/v0.4.11/deweb-plugin_windows_amd64.zip",
-        "checksum": "5c013a7123e6f9ceaa60b26f63bfc45f"
+        "url": "https://massa-station-assets.s3.eu-west-3.amazonaws.com/plugins/deweb/v0.4.12/deweb-plugin_windows_amd64.zip",
+        "checksum": "b697d6c4c4da2278227a3be24c1b8dba"
       },
       "linux": {
-        "url": "https://massa-station-assets.s3.eu-west-3.amazonaws.com/plugins/deweb/v0.4.11/deweb-plugin_linux_amd64.zip",
-        "checksum": "b0e3a1f088d467c02f7fbd45893ac1c9"
+        "url": "https://massa-station-assets.s3.eu-west-3.amazonaws.com/plugins/deweb/v0.4.12/deweb-plugin_linux_amd64.zip",
+        "checksum": "475e9ccf33e61378ec8476822a259292"
       },
       "macos-arm64": {
-        "url": "https://massa-station-assets.s3.eu-west-3.amazonaws.com/plugins/deweb/v0.4.11/deweb-plugin_darwin_arm64.zip",
-        "checksum": "bfda36ce35ddec4adc9c6f5f9748c130"
+        "url": "https://massa-station-assets.s3.eu-west-3.amazonaws.com/plugins/deweb/v0.4.12/deweb-plugin_darwin_arm64.zip",
+        "checksum": "e0b27b63322e79c6ae7bcae6c8d1cf5e"
       },
       "macos-amd64": {
-        "url": "https://massa-station-assets.s3.eu-west-3.amazonaws.com/plugins/deweb/v0.4.11/deweb-plugin_darwin_amd64.zip",
-        "checksum": "f2ea0638f9502ec0d0463009aa9a77d5"
+        "url": "https://massa-station-assets.s3.eu-west-3.amazonaws.com/plugins/deweb/v0.4.12/deweb-plugin_darwin_amd64.zip",
+        "checksum": "b6782f70bff498c260c4a6260824a86e"
       }
     },
-    "version": "0.4.11",
+    "version": "0.4.12",
     "url": "https://github.com/massalabs/deweb"
   },
   {


### PR DESCRIPTION
To fix the fact that deweb plugin cannot use the local node of node manager on windows